### PR TITLE
Small change to execute spotlessApply during build

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ subprojects {
     apply(plugin = "java-library")
     apply(plugin = "org.jetbrains.kotlin.jvm")
     apply(plugin = "io.spring.dependency-management")
+    apply(plugin = "com.diffplug.spotless")
 
     configure<io.spring.gradle.dependencymanagement.dsl.DependencyManagementExtension> {
         imports {
@@ -149,6 +150,7 @@ subprojects {
         options.encoding = "UTF-8"
         options.compilerArgs.add("-Xlint:unchecked")
 //        options.isDeprecation = true
+        dependsOn("spotlessApply")
     }
 
     tasks.jar {


### PR DESCRIPTION
This will ensure spotless compliant code in most cases, since most IDEs, such as IntelliJ uses the `build` task to build and this will automatically invoke `spotlessApply` on build.